### PR TITLE
feat(climate_ir): add old ballu protocol

### DIFF
--- a/components/climate/climate_ir.rst
+++ b/components/climate/climate_ir.rst
@@ -21,6 +21,8 @@ submit a feature request (see FAQ).
 +=======================================+=====================+======================+
 | Ballu                                 | ``ballu``           | yes                  |
 +---------------------------------------+---------------------+----------------------+
+| Old Ballu (BSC-09H)                   | ``ballu_old``       |                      |
++---------------------------------------+---------------------+----------------------+
 | Coolix                                | ``coolix``          | yes                  |
 +---------------------------------------+---------------------+----------------------+
 | Daikin                                | ``daikin``          | yes                  |
@@ -248,7 +250,7 @@ These air conditioners support two protocols: Midea and Coolix. Therefore, when 
 
 .. note::
 
-    - While they are identified as separate models here, the ``RAC-PT1411HWRU-C`` and ``RAC-PT1411HWRU-C`` are
+    - While they are identified as separate models here, the ``RAC-PT1411HWRU-C`` and ``RAC-PT1411HWRU-F`` are
       in fact the same physical model/unit. They are separated here only because different IR codes are used
       depending on the desired unit of measurement. This only affects how temperature is displayed on the unit itself.
 
@@ -376,6 +378,7 @@ See Also
 - :doc:`/components/remote_transmitter`
 - :doc:`/components/sensor/index`
 - :apiref:`ballu.h <ballu/ballu.h>`,
+  :apiref:`ballu_old.h <ballu_old/ballu_old.h>`,
   :apiref:`climate_ir_lg.h <climate_ir_lg/climate_ir_lg.h>`
   :apiref:`coolix.h <coolix/coolix.h>`,
   :apiref:`daikin.h <daikin/daikin.h>`


### PR DESCRIPTION
## Description:

Climate component for Ballu air conditioners with IR remote.
Tested on Ballu BSC-09H

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#7359<esphome PR number goes here>

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
